### PR TITLE
refactor: move `get_excel_sheet_names()` into `functions.py` for better unit testing

### DIFF
--- a/apps/app.py
+++ b/apps/app.py
@@ -206,16 +206,6 @@ def server(input: Inputs, output: Outputs, session: Session):
     reactive_dtypes_df = reactive.Value(pd.DataFrame())
 
     # Step 1: Upload a File
-    
-    def get_excel_sheet_names(file_path):
-        try:
-            workbook = openpyxl.load_workbook(file_path, read_only=True)
-            sheet_names = workbook.sheetnames
-            return sheet_names
-        except Exception as e:
-            print(f"Error reading Excel file: {e}")
-            return []
-
     @reactive.Effect
     def get_reactive_df():
 
@@ -261,7 +251,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             reactive_df.set(data_frame.reset_index().fillna("N/A"))
 
         else:
-            sheet_names = get_excel_sheet_names(file[0]["datapath"])
+            sheet_names = functions.get_excel_sheet_names(file[0]["datapath"])
             ui.update_selectize(
                 id="sheet_name",
                 choices=sheet_names,

--- a/apps/functions.py
+++ b/apps/functions.py
@@ -1,4 +1,5 @@
 from shiny import ui, render, App, Inputs, Outputs, Session, reactive
+import openpyxl
 
 def sep_input_radio_buttons():
     """
@@ -68,3 +69,12 @@ def yaxis_input_select(plot_type_str):
         selected = None,
         multiple = False
     )
+
+def get_excel_sheet_names(file_path):
+    try:
+        workbook = openpyxl.load_workbook(file_path, read_only=True)
+        sheet_names = workbook.sheetnames
+        return sheet_names
+    except Exception as e:
+        print(f"Error reading Excel file: {e}")
+        return []


### PR DESCRIPTION
This pull request refactors the `get_excel_sheet_names()` function by moving it into the `functions.py` file. This change improves the unit testing capabilities of the codebase.

closes #51