### PR TITLE
test: add unit test for `functions.py/get_excel_sheet_names()`

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -8,3 +8,15 @@ def test_get_file_id():
     assert functions.get_file_id(".csv") == "csv_file"
     assert functions.get_file_id(".tsv") == "tsv_file"
     assert functions.get_file_id(".xlsx") == "xlsx_file"
+
+def test_get_excel_sheet_names():
+    """
+    Test the `get_excel_sheet_names()` function. This function returns the names of the sheets in an Excel file.
+    """
+    assert functions.get_excel_sheet_names("tests/test_dataframe/xlsx_example_file.xlsx") == ["Sheet1", "Sheet2", "Sheet3"]
+
+def test_get_excel_sheet_names_invalid():
+    """
+    Test the `get_excel_sheet_names()` function. This function returns an empty list if the file path is invalid or there is an error reading the file.
+    """
+    assert functions.get_excel_sheet_names("tests/test_dataframe/invalid_file.xlsx") == []


### PR DESCRIPTION
This pull request adds a unit test for the `get_excel_sheet_names()` function in the `functions.py` file. The test ensures that the function returns a list of correct sheet names for a valid Excel file and an empty list for an invalid file or if there is an error reading the file.

closes #55 