### PR TITLE
fix: specify `apps` as parent package when importing `functions`

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,2 +1,2 @@
 # shiny/__init__.py
-from . import functions
+from apps import functions

--- a/apps/app.py
+++ b/apps/app.py
@@ -1,4 +1,4 @@
-from . import functions
+from apps import functions
 import openpyxl
 import pandas as pd
 import shinyswatch


### PR DESCRIPTION
This pull request corrects the import statement for the `functions` module in the `apps` package. Previously, the statement was

```python
from . import functions
```

but it has been updated to
```python
from apps import functions
```

This change ensures the correct module is imported, preventing potential import errors. Additionally, the ability to successfully generate documentation using `sphinx` has also been verified.

closes #73