### PR TITLE
fix(accessibility): address the issue where the pop-up messages were not accessible

### DIFF
--- a/apps/app.py
+++ b/apps/app.py
@@ -367,36 +367,44 @@ def server(input: Inputs, output: Outputs, session: Session):
         print("The convert button is clicked.")
         data_frame = reactive_df.get()
 
-        if data_frame is not None and not data_frame.empty:
-            column_to_convert: str = input.column_to_convert()
-            convert_dtype: str = input.convert_dtype()
+        if input.convert():
+            if data_frame is not None and not data_frame.empty:
+                column_to_convert: str = input.column_to_convert()
+                convert_dtype: str = input.convert_dtype()
 
-            if column_to_convert == "Select an option":
-                ui.notification_show("Please select a column to convert.")
+                if column_to_convert == "Select an option":
+                    message = ui.modal("Message: Please select a column to convert. Press Escape key or Dismiss button to close this message.",
+                                       easy_close=True)
+                    ui.modal_show(message)
 
-            elif convert_dtype == "Select an option":
-                ui.notification_show("Please select a data type to convert to.")
+                elif convert_dtype == "Select an option":
+                    message = ui.modal("Message: Please select a data type to convert to. \n Press Escape key or Dismiss button to close this message.",
+                                       easy_close=True)
+                    ui.modal_show(message)
 
-            elif (column_to_convert != "Select an option" and convert_dtype != "Select an option"):
-                try:
-                    updated_data_frame = data_frame.copy()
-                    updated_data_frame[column_to_convert] = updated_data_frame[column_to_convert].astype(convert_dtype)
-                    reactive_df.set(updated_data_frame)
-                    ui.notification_show(f"Successfully converted column [{column_to_convert}] to type [{convert_dtype}].")
+                elif (column_to_convert != "Select an option" and convert_dtype != "Select an option"):
+                    try:
+                        updated_data_frame = data_frame.copy()
+                        updated_data_frame[column_to_convert] = updated_data_frame[column_to_convert].astype(convert_dtype)
+                        reactive_df.set(updated_data_frame)
+                        message = ui.modal(f"Message: Successfully converted column [{column_to_convert}] to type [{convert_dtype}]. \n Press Escape key or Dismiss button to close this message.",
+                                           easy_close=True)
+                        ui.modal_show(message)
 
-                except ValueError as e:
-                    error_message: str = f"Failed to convert data in column '{column_to_convert}' to type '{convert_dtype}': {str(e)}"
-                    ui.notification_show(error_message)
+                    except ValueError as e:
+                        error_message: str = f"Message: Failed to convert data in column '{column_to_convert}' to type '{convert_dtype}': {str(e)} \n Press Escape key or Dismiss button to close this message."
+                        ui.modal_show(ui.modal(error_message,
+                                               easy_close=True))
 
-            data: dict = {"Column Name": [],
-                          "Data Type": []}
+                data: dict = {"Column Name": [],
+                            "Data Type": []}
 
-            for col in reactive_df.get().columns.to_list():
-                data["Column Name"].append(col)
-                data["Data Type"].append(str(type(reactive_df.get()[col][0])))
+                for col in reactive_df.get().columns.to_list():
+                    data["Column Name"].append(col)
+                    data["Data Type"].append(str(type(reactive_df.get()[col][0])))
 
-            updated_dtypes_df: pd.DataFrame = pd.DataFrame(data)
-            return render.DataGrid(updated_dtypes_df)
+                updated_dtypes_df: pd.DataFrame = pd.DataFrame(data)
+                return render.DataGrid(updated_dtypes_df)
 
     # Step 3: Select Plot Types
     @reactive.Effect


### PR DESCRIPTION
This pull request addresses the issue where the pop-up messages were not accessible.

In the data conversion step(step2), users need to select the column they want to convert and the datatype they want to convert to. Users need to click on the "Convert" button to activate the conversion. There are four situations where messages would pop up:

1. Users forgot to select the column (the default is "Select an option"). The pop-up message will remind users to select one.
2. Users forgot to select the datatype (the default is "Select an option"). The pop-up message will remind users to select one.
3. The column is successfully converted. The pop-up message will inform the users that the conversion was successful.
4. The column cannot be converted. The pop-up message will inform the users that it failed to convert the column.

In the previous version, I used `ui.notification_show()` to show the pop-up message, but it was not accessible. So in this PR, I changed it to `ui.modal` and `ui.modal_show`. In this way, messages can be read, and users can close the message by either pressing the escape key or clicking on the "Dismiss" button.

In this PR, another change is that the message will only be shown whenever the "Convert" button is clicked.

closes #77 