### PR TITLE
ci: add `lint-commit-message.yaml` to github action workflows

### DIFF
--- a/.github/workflows/lint-commit-message.yaml
+++ b/.github/workflows/lint-commit-message.yaml
@@ -1,0 +1,28 @@
+name: Lint Commit Messages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Ensures commit history is pulled
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Lint Commit Messages
+        run: npx commitlint --from=HEAD~1 --to=HEAD --verbose

--- a/.github/workflows/lint-commit-message.yaml
+++ b/.github/workflows/lint-commit-message.yaml
@@ -1,32 +1,3 @@
-# name: Lint Commit Messages
-
-# on:
-#   push:
-#     branches:
-#       - main
-#   pull_request:
-
-# jobs:
-#   commitlint:
-#     runs-on: ubuntu-latest
-
-#     steps:
-#       - name: Check out the repository
-#         uses: actions/checkout@v2
-#         with:
-#           fetch-depth: 0 # Ensures commit history is pulled
-
-#       - name: Install Node.js
-#         uses: actions/setup-node@v2
-#         with:
-#           node-version: 'lts/*'
-
-#       - name: Install Dependencies
-#         run: yarn install
-
-#       - name: Lint Commit Messages
-#         run: npx commitlint --from=HEAD~1 --to=HEAD --verbose
-
 name: Lint Commit Messages
 
 on:

--- a/.github/workflows/lint-commit-message.yaml
+++ b/.github/workflows/lint-commit-message.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           configFile: './commitlint.config.js'
           token: ${{ secrets.GITHUB_TOKEN }}
-          failOnWarnings: 'false'  # Set to true if you want warnings to cause the action to fail
+          # Set to true if you want warnings to cause the action to fail
+          failOnWarnings: 'false'
           # Add this line to check only the latest commit
           firstParent: true

--- a/.github/workflows/lint-commit-message.yaml
+++ b/.github/workflows/lint-commit-message.yaml
@@ -1,3 +1,32 @@
+# name: Lint Commit Messages
+
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+
+# jobs:
+#   commitlint:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#       - name: Check out the repository
+#         uses: actions/checkout@v2
+#         with:
+#           fetch-depth: 0 # Ensures commit history is pulled
+
+#       - name: Install Node.js
+#         uses: actions/setup-node@v2
+#         with:
+#           node-version: 'lts/*'
+
+#       - name: Install Dependencies
+#         run: yarn install
+
+#       - name: Lint Commit Messages
+#         run: npx commitlint --from=HEAD~1 --to=HEAD --verbose
+
 name: Lint Commit Messages
 
 on:
@@ -7,22 +36,10 @@ on:
   pull_request:
 
 jobs:
-  commitlint:
+  build:
+    name: Conventional Commits
     runs-on: ubuntu-latest
-
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # Ensures commit history is pulled
+      - uses: actions/checkout@v3
 
-      - name: Install Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 'lts/*'
-
-      - name: Install Dependencies
-        run: yarn install
-
-      - name: Lint Commit Messages
-        run: npx commitlint --from=HEAD~1 --to=HEAD --verbose
+      - uses: webiny/action-conventional-commits@v1.3.0

--- a/.github/workflows/lint-commit-message.yaml
+++ b/.github/workflows/lint-commit-message.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           configFile: './commitlint.config.js'
           token: ${{ secrets.GITHUB_TOKEN }}
+          
           # Set to true if you want warnings to cause the action to fail
           failOnWarnings: 'false'
           # Add this line to check only the latest commit

--- a/.github/workflows/lint-commit-message.yaml
+++ b/.github/workflows/lint-commit-message.yaml
@@ -1,6 +1,6 @@
 name: "Lint Commit Messages"
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   commitlint:
@@ -12,13 +12,12 @@ jobs:
           fetch-depth: 0  # Fetches the entire history which is necessary for commitlint to work correctly
 
       - name: Lint Commit Messages
-        uses: wagoid/commitlint-github-action@v4
+        uses: wagoid/commitlint-github-action@v5
         with:
           configFile: './commitlint.config.js'
-        #   token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           failOnWarnings: 'false'  # Set to true if you want warnings to cause the action to fail
           # Add this line to check only the latest commit
-          firstParent: true
           
       - name: Parse commitlint output
         id: parse_output

--- a/.github/workflows/lint-commit-message.yaml
+++ b/.github/workflows/lint-commit-message.yaml
@@ -12,21 +12,10 @@ jobs:
           fetch-depth: 0  # Fetches the entire history which is necessary for commitlint to work correctly
 
       - name: Lint Commit Messages
-        uses: wagoid/commitlint-github-action@v5
+        uses: wagoid/commitlint-github-action@v4
         with:
           configFile: './commitlint.config.js'
           token: ${{ secrets.GITHUB_TOKEN }}
           failOnWarnings: 'false'  # Set to true if you want warnings to cause the action to fail
           # Add this line to check only the latest commit
-          
-      - name: Parse commitlint output
-        id: parse_output
-        run: |
-            result=$(cat ${{ github.workspace }}/commitlint-result.json)
-            invalid_messages=$(echo "$result" | jq '.[] | select(.valid == false)')
-            echo "::set-output name=invalid_messages::$invalid_messages"
-        shell: bash
-
-      - name: Fail if commit linting fails
-        if: ${{ steps.parse_output.outputs.invalid_messages != '[]' }}
-        run: exit 1
+          firstParent: true

--- a/.github/workflows/lint-commit-message.yaml
+++ b/.github/workflows/lint-commit-message.yaml
@@ -1,16 +1,33 @@
-name: Lint Commit Messages
+name: "Lint Commit Messages"
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: [push, pull_request]
 
 jobs:
-  build:
-    name: Conventional Commits
+  commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Fetches the entire history which is necessary for commitlint to work correctly
 
-      - uses: webiny/action-conventional-commits@v1.3.0
+      - name: Lint Commit Messages
+        uses: wagoid/commitlint-github-action@v4
+        with:
+          configFile: './commitlint.config.js'
+        #   token: ${{ secrets.GITHUB_TOKEN }}
+          failOnWarnings: 'false'  # Set to true if you want warnings to cause the action to fail
+          # Add this line to check only the latest commit
+          firstParent: true
+          
+      - name: Parse commitlint output
+        id: parse_output
+        run: |
+            result=$(cat ${{ github.workspace }}/commitlint-result.json)
+            invalid_messages=$(echo "$result" | jq '.[] | select(.valid == false)')
+            echo "::set-output name=invalid_messages::$invalid_messages"
+        shell: bash
+
+      - name: Fail if commit linting fails
+        if: ${{ steps.parse_output.outputs.invalid_messages != '[]' }}
+        run: exit 1


### PR DESCRIPTION
This PR adds `lint-commit-message.yaml` to the GitHub Actions workflows(triggered when pushing to main branch or creating pull request). This ensures that all commit messages adhere to the conventional commit rules.

closes #142