### PR TITLE
fix: allow users to reset all selections and input file by clicking reset button

### DIFF
--- a/VizAble/upload_file.py
+++ b/VizAble/upload_file.py
@@ -29,21 +29,15 @@ def upload_ui() -> ui.nav_panel:
                         functions.sep_input_radio_buttons(),
                         ui.tags.hr(),
                         functions.quotechar_input_radio_buttons(),
-                        ui.tags.hr(),
-                        functions.input_file(".csv"),
                     ),
                     # Add condition: if user selects ".tsv" on file_format, they need to select quote character
                     # and only allowed to upload .tsv file
                     ui.panel_conditional(
                         "input.file_format == '.tsv'",
-                        ui.tags.hr(),
-                        functions.input_file(".tsv"),
                     ),
                     # Add condition: if user selects ".xlsx" on file_format, they are only allowed to upload .xlsx file
                     ui.panel_conditional(
                         "input.file_format == '.xlsx'",
-                        functions.input_file(".xlsx"),
-                        ui.tags.hr(),
                         ui.input_select(
                             id="sheet_name",
                             label=ui.strong("Sheet Name"),
@@ -52,6 +46,7 @@ def upload_ui() -> ui.nav_panel:
                             multiple=False,
                         ),
                     ),
+                    ui.output_ui("dynamic_file_input"),
                     ui.tooltip(
                         ui.input_action_button(
                             id="reset",


### PR DESCRIPTION
This PR introduces a dynamic file input feature enabling users to reset all selections and input files via a reset button. Shiny lacks a native method such as `ui.update_input_file` for resetting file input, so I fix this issue by implementing dynamic file input functionality. Furthermore, it resolves the issue where the output dataframe would reappear if the user selects the same file format after clicking the reset button.

closes #36