### PR TITLE
feat: add line plot example

### DIFF
--- a/VizAble/generate_plots.py
+++ b/VizAble/generate_plots.py
@@ -1,4 +1,5 @@
 from shiny import App, Inputs, Outputs, Session, reactive, render, ui, req, module
+from shinywidgets import output_widget, render_widget 
 
 def generate_plots_ui() -> ui.nav_panel:
     """ user interface for generating plots(step 5)
@@ -12,6 +13,32 @@ def generate_plots_ui() -> ui.nav_panel:
         ),
         ui.tags.br(),
         ui.card(
+            ui.layout_sidebar(
+                ui.sidebar(
+                    ui.input_text(
+                        id="plot_title",
+                        label="Plot Title",
+                        placeholder="Enter a plot title"
+                    ),
+                    ui.input_checkbox(
+                        id="markers",
+                        label="Show markers or not",
+                    ),
+                    # ui.input_select(
+                    #     id="color_by",
+                    #     label="Color by",
+                    #     choices=["--------"]
+                    # ),
+                    ui.tooltip(
+                        ui.input_action_button(
+                        id = "generate",
+                        label = "Generate Plot"
+                        ),
+                        "You can generate a plot by clicking this \"Generate Plot\" button, but if you have modify anything related to this plot, you need to click this button again to update the plot.",
+                    ),
+                ),
+                output_widget("get_output_plot"),
+            ),
             height="80vh",
         ),
     )

--- a/VizAble/select_columns.py
+++ b/VizAble/select_columns.py
@@ -20,7 +20,6 @@ def select_columns_ui() -> ui.nav_panel:
                         "input.plot_types == 'Line Plot'",
                         # add dropdown for x-axis and y-axis
                         functions.xaxis_input_select("line"),
-                        ui.tags.hr(),
                         functions.yaxis_input_select("line"),
                     ),
                     # Add condition: if user selects "Bar Plot" on plot_types
@@ -46,7 +45,6 @@ def select_columns_ui() -> ui.nav_panel:
                         "input.plot_types == 'Scatter Plot'",
                         # add dropdown for x-axis and y-axis
                         functions.xaxis_input_select("scatter"),
-                        ui.tags.hr(),
                         functions.yaxis_input_select("scatter"),
                     ),
                     open="always",

--- a/poetry.lock
+++ b/poetry.lock
@@ -959,6 +959,27 @@ test = ["pickleshare", "pytest (<7.1)", "pytest-asyncio (<0.22)", "testpath"]
 test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7.1)", "pytest-asyncio (<0.22)", "testpath", "trio"]
 
 [[package]]
+name = "ipywidgets"
+version = "8.1.2"
+description = "Jupyter interactive widgets"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ipywidgets-8.1.2-py3-none-any.whl", hash = "sha256:bbe43850d79fb5e906b14801d6c01402857996864d1e5b6fa62dd2ee35559f60"},
+    {file = "ipywidgets-8.1.2.tar.gz", hash = "sha256:d0b9b41e49bae926a866e613a39b0f0097745d2b9f1f3dd406641b4a57ec42c9"},
+]
+
+[package.dependencies]
+comm = ">=0.1.3"
+ipython = ">=6.1.0"
+jupyterlab-widgets = ">=3.0.10,<3.1.0"
+traitlets = ">=4.3.1"
+widgetsnbextension = ">=4.0.10,<4.1.0"
+
+[package.extras]
+test = ["ipykernel", "jsonschema", "pytest (>=3.6.0)", "pytest-cov", "pytz"]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.3.1"
 description = "Utility functions for Python class constructs"
@@ -1069,6 +1090,17 @@ traitlets = ">=5.3"
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "traitlets"]
 test = ["ipykernel", "pre-commit", "pytest (<8)", "pytest-cov", "pytest-timeout"]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.10"
+description = "Jupyter interactive widgets for JupyterLab"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jupyterlab_widgets-3.0.10-py3-none-any.whl", hash = "sha256:dd61f3ae7a5a7f80299e14585ce6cf3d6925a96c9103c978eda293197730cb64"},
+    {file = "jupyterlab_widgets-3.0.10.tar.gz", hash = "sha256:04f2ac04976727e4f9d0fa91cdc2f1ab860f965e504c29dbd6a65c882c9d04c0"},
+]
 
 [[package]]
 name = "keyring"
@@ -1586,6 +1618,21 @@ files = [
 [package.extras]
 docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
+
+[[package]]
+name = "plotly"
+version = "5.20.0"
+description = "An open-source, interactive data visualization library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "plotly-5.20.0-py3-none-any.whl", hash = "sha256:837a9c8aa90f2c0a2f0d747b82544d014dc2a2bdde967b5bb1da25b53932d1a9"},
+    {file = "plotly-5.20.0.tar.gz", hash = "sha256:bf901c805d22032cfa534b2ff7c5aa6b0659e037f19ec1e0cca7f585918b5c89"},
+]
+
+[package.dependencies]
+packaging = "*"
+tenacity = ">=6.2.0"
 
 [[package]]
 name = "pluggy"
@@ -2539,6 +2586,27 @@ docs = ["griffe (==0.32.3)", "plum-dispatch", "quartodoc (==0.4.2)", "shinylive"
 test = ["pytest (>=6.2.4)"]
 
 [[package]]
+name = "shinywidgets"
+version = "0.3.1"
+description = "Render ipywidgets in Shiny applications"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "shinywidgets-0.3.1-py3-none-any.whl", hash = "sha256:03b560c93aca283ba472f566fae81420366c87f6b661969e905e8796d2928f5a"},
+    {file = "shinywidgets-0.3.1.tar.gz", hash = "sha256:bd7b37539cc2fe6c8f91e9f517bfc322385c26faef61c395ae8cf4f8cb8d519e"},
+]
+
+[package.dependencies]
+ipywidgets = ">=7.6.5"
+jupyter-core = "*"
+python-dateutil = ">=2.8.2"
+shiny = ">=0.6.1.9005"
+
+[package.extras]
+dev = ["black (>=23.1.0)", "flake8 (==3.9.2)", "flake8 (>=6.0.0)", "isort (>=5.11.2)", "pyright (>=1.1.284)", "wheel"]
+test = ["pytest (>=6.2.4)"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -2761,6 +2829,20 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
+
+[[package]]
+name = "tenacity"
+version = "8.2.3"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tenacity-8.2.3-py3-none-any.whl", hash = "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"},
+    {file = "tenacity-8.2.3.tar.gz", hash = "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
 
 [[package]]
 name = "tomli"
@@ -3131,6 +3213,17 @@ files = [
 test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
 [[package]]
+name = "widgetsnbextension"
+version = "4.0.10"
+description = "Jupyter interactive widgets for Jupyter Notebook"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "widgetsnbextension-4.0.10-py3-none-any.whl", hash = "sha256:d37c3724ec32d8c48400a435ecfa7d3e259995201fbefa37163124a9fcb393cc"},
+    {file = "widgetsnbextension-4.0.10.tar.gz", hash = "sha256:64196c5ff3b9a9183a8e699a4227fb0b7002f252c814098e66c4d1cd0644688f"},
+]
+
+[[package]]
 name = "xattr"
 version = "1.1.0"
 description = "Python wrapper for extended filesystem attributes"
@@ -3221,4 +3314,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9 || ^3.10 || ^3.11"
-content-hash = "85016d5114c42755ee230bb245e4b9b6186b46579348577a4c21a7054d4bbe4d"
+content-hash = "730de510906b72a2e5f9177e86cb69497da5737b8b1f8d8f33e593a9664e3758"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ wheel = "^0.42.0"
 sphinx = "^7.2.6"
 sphinx-press-theme = "^0.8.0"
 rsconnect-python = "^1.22.0"
+shinywidgets = "^0.3.1"
+plotly = "^5.20.0"
 
 [tool.poetry.scripts]
 "VizAble.run_app" = "VizAble.app:main"


### PR DESCRIPTION
This PR adds the shinywidgets and plotly packages to the project, enabling the generation of interactive plots. It also includes a new example demonstrating a line plot.

These examples are temporary placeholders until implementing maidr. In this PR, users can create a line plot. After selecting "Line Plot" as their desired plot type and choosing their x-axis and y-axis variables in step 4 (Select Columns), they should enter the plot title in the "Plot Title" text input and indicate whether they want markers for the plot in step 5 (Generate Plots). Afterward, they can click the "Generate Plot" button. The plot will be generated on the main panel only upon clicking this button. If users wish to modify the data, they need to click "Generate Plot" again to display the updated plot.

Closes #159