### PR TITLE
chore: trigger python-semantic-release every three days at 00:00 EST(05:00 UTC)

### DIFF
--- a/.github/workflows/python-semantic-release.yaml
+++ b/.github/workflows/python-semantic-release.yaml
@@ -8,9 +8,9 @@
 name: python-semantic-release
 
 on:
-  # triggered every day at 00:00
+  # triggered every three days at 00:00 EST (05:00 UTC)
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 5 */3 * *'
 
   # triggered manually
   workflow_dispatch:


### PR DESCRIPTION
This PR  updates the schedule for triggering the python-semantic-release workflow. Instead of being triggered every day at 00:00 UTC, it will now be triggered every three days at 00:00 EST (05:00 UTC). This change ensures that the workflow runs less frequently, reducing unnecessary resource usage.

closes #161