### PR TITLE
chore: trigger shinyappsio-deployment workflow on new github release

### DIFF
--- a/.github/workflows/shinyappsio-deployment.yaml
+++ b/.github/workflows/shinyappsio-deployment.yaml
@@ -1,6 +1,9 @@
 name: shinyappsio-deployment
 
 on:
+  # triggered when a new release is created
+  release:
+    types: [created]
   # Triggered manually or when there are changes pushed to the master branch
   workflow_dispatch:
 


### PR DESCRIPTION
This PR updates the shinyappsio-deployment workflow and triggers it when a new GitHub release is created, which occurs when the python-semantic-release workflow has passed and a release has been made.

closes #169