### PR TITLE
feat: generate grouped box plot

### DIFF
--- a/VizAble/functions.py
+++ b/VizAble/functions.py
@@ -129,6 +129,16 @@ def yaxis_input_select(plot_type_str: str) -> ui.input_select:
         multiple = False
     )
 
+def grouping_input_select(plot_type_str: str) -> ui.input_select:
+    grouping_id = f"{plot_type_str}_grouping"
+    return ui.input_select(
+        id = grouping_id,
+        label = ui.strong("Group By"),
+        choices = [],
+        selected = None,
+        multiple = False
+    )
+
 def get_excel_sheet_names(file_path: Path) -> List[str]:
     """ Get a list of all sheet names for the uploaded Excel file.
 
@@ -160,9 +170,11 @@ def return_choices_for_columns(data_frame: pd.DataFrame, plot_type: str) -> List
     
     # Mapping of plot types to data types they accept(add more if needed)
     plot_type_to_dtypes = {
+        "Categorical": ["object", "category"],
         "Line Plot": None,
         "Bar Plot": ["object", "category"],
         "Box Plot": ["number"],
+        "Grouped_Box Plot": ["number"],
         "Histogram": ["number"],
         "Scatter Plot": ["number"],
     }
@@ -209,6 +221,15 @@ def update_yaxis_input_select(plot_type: str, choices: List[str]) -> ui.update_s
 
     return ui.update_select(
         id=axis_id,
+        choices=choices,
+        selected=None
+    )
+
+def update_grouping_input_select(plot_type: str, choices: List[str]) -> ui.update_select:
+    grouping_id = plot_type.split(" ")[0].lower() + "_grouping"
+
+    return ui.update_select(
+        id=grouping_id,
         choices=choices,
         selected=None
     )

--- a/VizAble/generate_plots.py
+++ b/VizAble/generate_plots.py
@@ -59,6 +59,21 @@ def generate_plots_ui() -> ui.nav_panel:
                         ),
                     ),
 
+                    # Show when user selects "Grouped_Box Plot" on plot_types
+                    ui.panel_conditional(
+                        "input.plot_types == 'Grouped_Box Plot'",
+                        ui.input_text(
+                            id="grouped_box_plot_title",
+                            label="Plot Title",
+                            placeholder="Enter a plot title"
+                        ),
+                        ui.input_text(
+                            id="grouped_box_y_axis_title",
+                            label="Y-axis Title",
+                            placeholder="Enter a title for the y-axis"
+                        ),
+                    ),
+
                     # Show when user selects "Bar Plot" on plot_types
                     ui.panel_conditional(
                         "input.plot_types == 'Bar Plot'",

--- a/VizAble/select_columns.py
+++ b/VizAble/select_columns.py
@@ -34,6 +34,12 @@ def select_columns_ui() -> ui.nav_panel:
                         # add dropdown for x-axis
                         functions.yaxis_input_select("box"),
                     ),
+                    # Add condition: if user selects "Grouped_Box Plot" on plot_types
+                    ui.panel_conditional(
+                        "input.plot_types == 'Grouped_Box Plot'",
+                        functions.yaxis_input_select("grouped_box"),
+                        functions.grouping_input_select("grouped_box"),
+                    ),
                     # Add condition: if user selects "Histogram" on plot_types
                     ui.panel_conditional(
                         "input.plot_types == 'Histogram'",


### PR DESCRIPTION
This PR adds functionality to generate grouped box plots. This feature enables the creation of box plots for different groups, rather than just one field or column. When selecting a column, the user needs to choose both a numerical column to display the distribution and a categorical column to compare the differences between multiple groups.

closes #179