### PR TITLE
test: add unit test for `update_grouping_input_select()` function

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -113,9 +113,11 @@ def test_get_excel_sheet_names_invalid():
 # Test return_choices_for_columns()
 @pytest.mark.parametrize("plot_type,expected_columns",
                          [
+                             ("Categorical", ["Select an option", "Entity", "Code"]),
                              ("Line Plot", ["Select an option", "Entity", "Code", "Year", "Users"]),
                              ("Bar Plot", ["Select an option", "Entity", "Code"]),
                              ("Box Plot", ["Select an option", "Year", "Users"]),
+                             ("Grouped_Box Plot", ["Select an option", "Year", "Users"]),
                              ("Histogram", ["Select an option", "Year", "Users"]),
                              ("Scatter Plot", ["Select an option", "Year", "Users"])
                          ])
@@ -230,6 +232,7 @@ def test_update_xaxis_input_select(plot_type: str, expected_id: str):
                              ("Line Plot", "line_y_axis"),
                              ("Bar Plot", "bar_y_axis"),
                              ("Box Plot", "box_y_axis"),
+                             ("Grouped_Box Plot", "grouped_box_y_axis"),
                              ("Histogram", "histogram_y_axis"),
                              ("Scatter Plot", "scatter_y_axis")
                          ])
@@ -246,6 +249,28 @@ def test_update_yaxis_input_select(plot_type: str, expected_id: str):
 
     with patch("VizAble.functions.ui.update_select") as mock_update_select:
         functions.update_yaxis_input_select(plot_type, choices)
+        mock_update_select.assert_called_once_with(id=expected_id,
+                                                   choices=choices,
+                                                   selected=None)
+        
+# Test update_grouping_input_select()
+@pytest.mark.parametrize("plot_type, expected_id",
+                         [
+                            ("grouped_box", "grouped_box_grouping")
+                         ])
+
+def test_update_grouping_input_select(plot_type: str, expected_id: str):
+    """ Test the `update_grouping_input_select()` function. This function updates the grouping dropdown based on the selected plot type.
+
+    :param plot_type: the plot type passed to the function
+    :type plot_type: str
+    :param expected_id: the expected id for the updated input select
+    :type expected_id: str
+    """
+    choices = ["col1", "col2", "col3"]
+
+    with patch("VizAble.functions.ui.update_select") as mock_update_select:
+        functions.update_grouping_input_select(plot_type, choices)
         mock_update_select.assert_called_once_with(id=expected_id,
                                                    choices=choices,
                                                    selected=None)


### PR DESCRIPTION
This PR adds a unit test for the `update_grouping_input_select()` function in the VizAble project. The test ensures that the function correctly updates the grouping dropdown based on the selected plot type.

closes #185